### PR TITLE
Add exiftool to extract mp4 exif info

### DIFF
--- a/exif_processing.py
+++ b/exif_processing.py
@@ -6,6 +6,7 @@ from typing import Optional
 # third party
 import exifread
 import piexif
+import exiftool
 
 MPH_TO_KMH_FACTOR = 1.60934
 """miles per hour to kilometers per hour conversion factor"""
@@ -83,6 +84,15 @@ def all_tags(path) -> {str: str}:
     file = open(path, "rb")
     tags = exifread.process_file(file, details=False)
     return tags
+
+
+def video_tags(path) -> {str: str}:
+    """Method to return video's Exif tags"""
+    with exiftool.ExifTool() as et:
+        metadata = et.get_metadata(path)
+        if not metadata:
+            return {} 
+        return metadata
 
 
 def __dms_to_dd(dms_value) -> float:

--- a/osc_discoverer.py
+++ b/osc_discoverer.py
@@ -10,7 +10,7 @@ from visual_data_discover import PhotoMetadataDiscoverer
 from visual_data_discover import VideoDiscoverer
 from validators import SequenceValidator, SequenceMetadataValidator, SequenceFinishedValidator
 from osc_utils import unzip_metadata
-from osc_models import Sequence, Photo
+from osc_models import Sequence, Photo, Video
 
 
 LOGGER = logging.getLogger('osc_tools.osc_discoverer')
@@ -148,7 +148,7 @@ class SequenceDiscoverer:
                     sequence.longitude = gps.longitude
             elif sequence.visual_items:
                 visual_item = sequence.visual_items[0]
-                if isinstance(visual_item, Photo):
+                if isinstance(visual_item, Photo) or isinstance(visual_item, Video):
                     sequence.latitude = visual_item.latitude
                     sequence.longitude = visual_item.longitude
 

--- a/osc_models.py
+++ b/osc_models.py
@@ -77,6 +77,17 @@ class Photo(VisualData):
 
 class Video(VisualData):
     """Video is a VisualData model for a video item"""
+
+    def __init__(self, path):
+        super().__init__(path)
+        self.latitude: float = None
+        self.longitude: float = None
+        self.exif_timestamp: float = None
+        self.gps_timestamp: float = None
+        self.gps_speed: float = None
+        self.gps_altitude: float = None
+        self.gps_compass: float = None
+
     def __eq__(self, other):
         if isinstance(other, Video):
             return self.path == other.path and self.index == other.index

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ ExifRead==2.1.2
 tqdm==4.29.1
 piexif==1.1.2
 pycodestyle==2.5.0
+PyExifTool==0.4.7


### PR DESCRIPTION
Before uploading the mp4 video record to openstreetcam, the mp4 file
needed to extract the GPS information.

This commit add the exiftool package to extract GPS information from
mp4 file and implemented the videodiscover for uploading.