### PR TITLE
Add filename as secondary sort column in case GPS timestamp matches

### DIFF
--- a/visual_data_discover.py
+++ b/visual_data_discover.py
@@ -118,7 +118,7 @@ class ExifPhotoDiscoverer(PhotoDiscovery):
 
     @classmethod
     def _sort_photo_list(cls, photos):
-        photos.sort(key=lambda p: p.gps_timestamp)
+        photos.sort(key=lambda p: (p.gps_timestamp, os.path.basename(p.path)))
 
 
 class PhotoMetadataDiscoverer(PhotoDiscovery):


### PR DESCRIPTION
As mentioned in #127, when I tried to upload a time lapse sequence taken with a GoPro Hero 8 Black with an interval of less than one second, the GPS timestamp field didn't have the necessary resolution to order the images correctly. This PR uses the filename as a secondary column when sorting.